### PR TITLE
Clean things up some

### DIFF
--- a/src/Data/MedianStream.hs
+++ b/src/Data/MedianStream.hs
@@ -42,26 +42,29 @@ data MedianStream a = MedianStream !(Left a) !(Right a)
 --    Heap.size rh <= Heap.size lh <= Heap.size rh + 1
 
 -- | Infix wrapper around insert with the MedianStream on the left.
--- Complexity: O(lgn)
+--
+-- Complexity: \( O (\lg n) \)
 (+>) :: Ord a => MedianStream a -> a -> MedianStream a
 (+>) ms a = insert a ms
 
 -- | Infix wrapper around insert with the MedianStream on the right.
--- Complexity: O(lgn)
+-- Complexity: \( O (\lg n) \)
 (<+) :: Ord a => a -> MedianStream a -> MedianStream a
 (<+) = insert
 
 -- | Create an empty MedianStream with no values.
--- Complexity: O(1)
+--
+-- Complexity: \( O(1) \)
 empty :: MedianStream a
 empty = MedianStream Heap.empty Heap.empty
 
 -- | Insert a new numeric value into the median stream.
--- Complexity: O(lgn)
+--
+-- Complexity: \( O(\lg n) \)
 insert :: Ord a => a -> MedianStream a -> MedianStream a
 insert a ms@(MedianStream lh rh)
-  -- | Heap.size lh < Heap.size rh = error "boom"
-  -- | Heap.size lh > Heap.size rh + 1 = error "bang"
+  -- \| Heap.size lh < Heap.size rh = error "boom"
+  -- \| Heap.size lh > Heap.size rh + 1 = error "bang"
   | even $ size ms = oddMedianStream
   | otherwise      = evenMedianStream
   where
@@ -91,7 +94,7 @@ insert a ms@(MedianStream lh rh)
 -- | Query the 'MedianStream' for the median of the stream of numbers
 -- inserted so far.
 --
--- Complexity: O(1)
+-- Complexity: \( O(1) \)
 median :: (Real a, Fractional b) => MedianStream a -> Maybe b
 median ms@(MedianStream lh rh)
   | even $ size ms = average <$> Heap.viewHead lh <*> Heap.viewHead rh
@@ -103,7 +106,7 @@ median ms@(MedianStream lh rh)
 -- | A version of 'median' optimized for the case where the result
 -- type is the same as the element type.
 --
--- Complexity: O(1)
+-- Complexity: \( O(1) \)
 medianSame :: (Real a, Fractional a) => MedianStream a -> Maybe a
 medianSame ms@(MedianStream lh rh)
   | even $ size ms = averageSame <$> Heap.viewHead lh <*> Heap.viewHead rh
@@ -112,17 +115,19 @@ medianSame ms@(MedianStream lh rh)
     averageSame x l = (x + l)/2
 
 -- | Returns the number of elements in the MedianStream.
--- Complexity: O(1)
+--
+-- Complexity: \( O(1) \)
 size :: MedianStream a -> Int
 size (MedianStream lh rh) = Heap.size lh + Heap.size rh
 
 -- | Creates a MedianStream from a list of input elements.
--- Complexity: O(n lg n)
+--
+-- Complexity: \( O(n \lg n) \)
 fromList :: Real a => [a] -> MedianStream a
 fromList = insertList empty
 
 -- | Adds a list of input elements to an existing MedianStream
--- Complexity: O(n lg n)
+--
+-- Complexity: \( O(n \lg n) \)
 insertList :: Real a => MedianStream a -> [a] -> MedianStream a
 insertList = foldl' (+>)
-

--- a/src/Data/MedianStream.hs
+++ b/src/Data/MedianStream.hs
@@ -33,6 +33,7 @@ type Right a = MinHeap a
 -- | A MedianStream is a data type that can be inserted into and queried
 -- to get a median of a stream of numeric values.
 data MedianStream a = MedianStream !(Left a) !(Right a)
+  deriving Eq
 -- Invariants:
 --
 -- 1. Each element of the left heap is less than or equal to each

--- a/src/Data/MedianStream.hs
+++ b/src/Data/MedianStream.hs
@@ -8,8 +8,6 @@ Stability   : experimental
 Portability : POSIX
 -}
 
-{-# LANGUAGE GADTs #-}
-
 module Data.MedianStream
 (
   MedianStream
@@ -18,6 +16,7 @@ module Data.MedianStream
 , empty
 , insert
 , median
+, medianSame
 , size
 , fromList
 , insertList
@@ -25,56 +24,92 @@ module Data.MedianStream
 
 import Control.Applicative ((<$>), (<*>))
 import Data.Heap (MaxHeap, MinHeap, Heap)
-import qualified Data.Heap as Heap hiding (MaxHeap, MinHeap, Heap)
+import qualified Data.Heap as Heap
 import Data.List (foldl')
-import Data.Maybe (fromJust)
 
 type Left a  = MaxHeap a
 type Right a = MinHeap a
 
 -- | A MedianStream is a data type that can be inserted into and queried
 -- to get a median of a stream of numeric values.
-data MedianStream a where
-  MedianStream :: (Real a, Eq a) => Left a -> Right a -> MedianStream a
+data MedianStream a = MedianStream !(Left a) !(Right a)
+-- Invariants:
+--
+-- 1. Each element of the left heap is less than or equal to each
+--    element of the right heap
+--
+-- 2. In MedianStream lh rh,
+--    Heap.size rh <= Heap.size lh <= Heap.size rh + 1
 
 -- | Infix wrapper around insert with the MedianStream on the left.
 -- Complexity: O(lgn)
-(+>) :: MedianStream a -> a -> MedianStream a
+(+>) :: Ord a => MedianStream a -> a -> MedianStream a
 (+>) ms a = insert a ms
 
 -- | Infix wrapper around insert with the MedianStream on the right.
 -- Complexity: O(lgn)
-(<+) :: a -> MedianStream a -> MedianStream a
+(<+) :: Ord a => a -> MedianStream a -> MedianStream a
 (<+) = insert
 
 -- | Create an empty MedianStream with no values.
 -- Complexity: O(1)
-empty :: (Real a, Eq a) => MedianStream a
+empty :: MedianStream a
 empty = MedianStream Heap.empty Heap.empty
 
 -- | Insert a new numeric value into the median stream.
 -- Complexity: O(lgn)
-insert :: a -> MedianStream a -> MedianStream a
+insert :: Ord a => a -> MedianStream a -> MedianStream a
 insert a ms@(MedianStream lh rh)
+  -- | Heap.size lh < Heap.size rh = error "boom"
+  -- | Heap.size lh > Heap.size rh + 1 = error "bang"
   | even $ size ms = oddMedianStream
   | otherwise      = evenMedianStream
-    where
-      oddMedianStream
-        | maybe False (a >=) $ Heap.viewHead rh =
-          uncurry MedianStream $ popAndSwap lh rh a
-        | otherwise = MedianStream (Heap.insert a lh) rh
-      evenMedianStream
-        | maybe False (a < ) $ Heap.viewHead lh =
-          uncurry (flip MedianStream) $ popAndSwap rh lh a
-        | otherwise = MedianStream lh (Heap.insert a rh)
+  where
+    -- Note: One might reasonably be concerned about using
+    -- Heap.view when we may only need the greatest/least
+    -- element. But Heap.view builds the remaining heap
+    -- lazily, so we don't actually have to build it unless
+    -- we need it. And everything inlines nicely, so we shouldn't
+    -- even build the unnecessary thunks. Furthermore,
+    -- viewHead itself is implemented using view, so using that
+    -- surely won't help us.
 
--- | Query the MedianStream for the median of the stream of numbers
+    -- The result has an odd number of elements
+    oddMedianStream
+      | Just (mid, tl) <- Heap.view rh
+      , a >= mid
+      = MedianStream (Heap.insert mid lh) (Heap.insert a tl)
+      | otherwise = MedianStream (Heap.insert a lh) rh
+
+    -- The result has an even number of elements
+    evenMedianStream
+      | Just (mid, tl) <- Heap.view lh
+      , a < mid
+      = MedianStream (Heap.insert a tl) (Heap.insert mid rh)
+      | otherwise = MedianStream lh (Heap.insert a rh)
+
+-- | Query the 'MedianStream' for the median of the stream of numbers
 -- inserted so far.
+--
 -- Complexity: O(1)
-median :: MedianStream a -> Maybe Double
+median :: (Real a, Fractional b) => MedianStream a -> Maybe b
 median ms@(MedianStream lh rh)
   | even $ size ms = average <$> Heap.viewHead lh <*> Heap.viewHead rh
-  | otherwise      = (fromRational . toRational) <$> Heap.viewHead lh
+  | otherwise      = fromRational . toRational <$> Heap.viewHead lh
+  where
+    average x l = (/2 ) . fromRational $ toRational (x + l)
+
+
+-- | A version of 'median' optimized for the case where the result
+-- type is the same as the element type.
+--
+-- Complexity: O(1)
+medianSame :: (Real a, Fractional a) => MedianStream a -> Maybe a
+medianSame ms@(MedianStream lh rh)
+  | even $ size ms = averageSame <$> Heap.viewHead lh <*> Heap.viewHead rh
+  | otherwise      = Heap.viewHead lh
+  where
+    averageSame x l = (x + l)/2
 
 -- | Returns the number of elements in the MedianStream.
 -- Complexity: O(1)
@@ -82,27 +117,12 @@ size :: MedianStream a -> Int
 size (MedianStream lh rh) = Heap.size lh + Heap.size rh
 
 -- | Creates a MedianStream from a list of input elements.
--- Complexity: O(nlgn)
-fromList :: (Real a, Eq a) => [a] -> MedianStream a
+-- Complexity: O(n lg n)
+fromList :: Real a => [a] -> MedianStream a
 fromList = insertList empty
 
 -- | Adds a list of input elements to an existing MedianStream
--- Complexity: O(nlgn)
-insertList :: (Real a, Eq a) => MedianStream a -> [a] -> MedianStream a
+-- Complexity: O(n lg n)
+insertList :: Real a => MedianStream a -> [a] -> MedianStream a
 insertList = foldl' (+>)
 
-popAndSwap :: (Heap.HeapItem pol1 a,
-               Heap.HeapItem pol2 a)
-           => Heap pol1 a
-           -> Heap pol2 a
-           -> a
-           -> (Heap pol1 a, Heap pol2 a)
-popAndSwap lh rh a =
-  let
-    ([top], srh) = Heap.splitAt 1 rh
-    nlh          = Heap.insert top lh
-    nrh          = Heap.insert a   srh
-    in (nlh, nrh)
-
-average :: (Real a) => a -> a -> Double
-average x l = (/2 ) . fromRational $ toRational (x + l)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import Data.List hiding (insert)
 import Data.MedianStream
 import Test.QuickCheck
 import Utils
+import System.Exit
 
 prop_medianStreamOnInts :: [Int] -> Bool
 prop_medianStreamOnInts xs = medianOf xs == median (foldr insert empty xs)
@@ -48,6 +49,13 @@ halves ls = splitAt mid ls
   where mid = length ls `div` 2
 
 return []
+
+runTests :: IO Bool
 runTests = $quickCheckAll
 
-main = runTests
+main :: IO ()
+main = do
+  good <- runTests
+  if good
+    then exitSuccess
+    else exitFailure


### PR DESCRIPTION
* Use `view` instead of `splitAt`.
* Use pattern guards to clarify.
* Remove redundant constraints.
* Make the constructor strict, which is semantically correct
  and should make things easier for the optimizer.
* Get rid of the existential quantification. This is a breaking
  change, but I think it's the Right Thing. It should
  help the specializer a lot and sometimes reduce allocation.
  Almost no other packages use an existential the way this did.
* Generalize the type of `median` to produce non-`Double` results.
* Add a version of `median` specialized to the case where the element
  type is the same as the result type.
* Get rid of `popAndSwap`. Inlining it removes an incomplete
  pattern match and I think also makes the code significantly
  clearer. 
* Document invariants.
* Make the test suite fail properly when things are broken