### PR TITLE
Generalize what could be

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <a href="https://hackage.haskell.org/package/median-stream">Hackage</a>
 [![Build Status](https://travis-ci.org/caneroj1/median-stream.svg?branch=master)](https://travis-ci.org/caneroj1/median-stream)
 <br>
-Haskell data structure for constant-time queries for the median of a stream of numeric data, where insertion into the stream occurs in O(nlgn). ```median-stream``` uses two heaps (a max-heap and a min-heap) to enable constant time access to the median. If there is an even number of elements in the stream, then the median is the average of the head of the two heaps. If there is an odd number, the median is the head of the max heap.
+Haskell data structure for constant-time queries for the median of a stream of ordered data, where insertion into the stream occurs in O(nlgn). ```median-stream``` uses two heaps (a max-heap and a min-heap) to enable constant time access to the median. If there is an even number of numeric elements in the stream, then the median is the average of the head of the two heaps. If there is an odd number, the median is the head of the max heap.
 
 ## Usage
 
@@ -13,4 +13,9 @@ Just 2.5
 Data.MedianStream> let medianStream2 = medianStream +> 0 +> (-1) +> 10
 Data.MedianStream> median medianStream2
 Just 2.0
+λ> let medianStream3 = fromList [GT,LT,LT,GT]
+λ> medianWith undefined (,) medianStream3
+Just (LT,GT)
+λ> medianWith id undefined (insert EQ medianStream3)
+Just EQ
 ```

--- a/src/Data/MedianStream.hs
+++ b/src/Data/MedianStream.hs
@@ -129,11 +129,11 @@ size (MedianStream lh rh) = Heap.size lh + Heap.size rh
 -- | Creates a MedianStream from a list of input elements.
 --
 -- Complexity: \( O(n \lg n) \)
-fromList :: Ord a => [a] -> MedianStream a
+fromList :: (Foldable f,Ord a) => f a -> MedianStream a
 fromList = insertList empty
 
 -- | Adds a list of input elements to an existing MedianStream
 --
 -- Complexity: \( O(n \lg n) \)
-insertList :: Ord a => MedianStream a -> [a] -> MedianStream a
+insertList :: (Foldable f,Ord a) => MedianStream a -> f a -> MedianStream a
 insertList = foldl' (+>)


### PR DESCRIPTION
This PR is dependent on and bases off PR#2. (cc @treeowl)

* generalize from `Real` data to `Ord`.
* generalize the list inputs to `Foldable`.

This leaves the implementation unchanged, simply extracting a more generic `medianWith` that delegates to whatever continuations are provided. This nicely factors the previous `median` and `medianSame`.